### PR TITLE
Include actuated state into active_keys

### DIFF
--- a/AnalogSense.js
+++ b/AnalogSense.js
@@ -334,7 +334,7 @@ class AsProvider
         const active_keys = [];
         for (const [scancode, value] of Object.entries(this.buffer))
         {
-            active_keys.push({ scancode, value });
+            active_keys.push({ scancode, value, actuated: null });
         }
         return active_keys;
     }
@@ -361,7 +361,7 @@ class AsProviderWootingV1 extends AsProvider
                 const scancode = (event.data.getUint8(i++) << 8) | event.data.getUint8(i++);
                 if (scancode == 0) break;
                 const value = event.data.getUint8(i++);
-                active_keys.push({ scancode, value: value / 255 });
+                active_keys.push({ scancode, value: value / 255, actuated: null });
             }
             handler(active_keys);
         };
@@ -396,6 +396,7 @@ class AsProviderWootingV2 extends AsProvider
                 const packed       = data.getUint8(i + 2);
                 const value_hi     = data.getUint8(i + 3);
 
+                const actuated      = packed & 0x1;
                 const keyNamespace = (packed >> 2) & 0xf;
                 const value_lo     = (packed >> 6) & 0x3;
 
@@ -405,7 +406,7 @@ class AsProviderWootingV2 extends AsProvider
                 if (scancode === 0) break;
                 if (value === 0) continue;
 
-                active_keys.push({ scancode, value: value / 1023 });
+                active_keys.push({ scancode, value: value / 1023, actuated });
             }
             handler(active_keys);
         };
@@ -442,7 +443,8 @@ class AsProviderRazerHuntsman extends AsProvider
                     const value = event.data.getUint8(i++);
                     active_keys.push({
                         scancode: analogsense.razerScancodeToHidScancode(scancode),
-                        value: value / 255
+                        value: value / 255,
+                        actuated: null
                     });
                 }
                 handler(active_keys);
@@ -483,7 +485,8 @@ class AsProviderRazerHuntsmanV3 extends AsProvider
                     i++; // unclear, might be something like "priority."
                     active_keys.push({
                         scancode: analogsense.razerScancodeToHidScancode(scancode),
-                        value: value / 255
+                        value: value / 255,
+                        actuated: null
                     });
                 }
                 handler(active_keys);
@@ -575,7 +578,8 @@ class AsProviderDrunkdeer extends AsProvider
                 {
                     this.active_keys.push({
                         scancode: analogsense.drunkdeerIndexToHidScancode((n * (64 - 5)) + (i - 4)),
-                        value: value / 40
+                        value: value / 40,
+                        actuated: null
                     });
                 }
             }

--- a/AnalogSense.js
+++ b/AnalogSense.js
@@ -386,28 +386,48 @@ class AsProviderWootingV2 extends AsProvider
         this.dev.oninputreport = function(event)
         {
             const active_keys = [];
+            const features_by_pos = {};
             const data = event.data;
             //each entry is 4 bytes (pos, keycode, namespace + analog lo, analog depth
             //namespace 0 are regular hid keys, non zero are media keys
             //analog value is 10bit 0 to 1023
+            //
+            //namespace 6 are `advanced keys` (like socd dks etc etc)
+            //with which we can check if the user has configured eg socd on them or nah
             for (let i = 0; i + 4 <= data.byteLength; i += 4)
             {
-                const keycode      = data.getUint8(i + 1);
-                const packed       = data.getUint8(i + 2);
-                const value_hi     = data.getUint8(i + 3);
+                const matrix_pos    = data.getUint8(i + 0);
+                const keycode       = data.getUint8(i + 1);
+                const packed        = data.getUint8(i + 2);
+                const value_hi      = data.getUint8(i + 3);
 
-                const actuated      = packed & 0x1;
-                const keyNamespace = (packed >> 2) & 0xf;
-                const value_lo     = (packed >> 6) & 0x3;
+                const actuated      = (packed & 0x1) !== 0;
+                const key_namespace = (packed >> 2) & 0xf;
+                const value_lo      = (packed >> 6) & 0x3;
+                const value         = (value_hi << 2) | value_lo;
 
-                const scancode = (keyNamespace << 8) | keycode;
-                const value    = (value_hi << 2) | value_lo;
-
-                if (scancode === 0) break;
+                if (matrix_pos === 0 && keycode === 0) break;
                 if (value === 0) continue;
 
-                active_keys.push({ scancode, value: value / 1023, actuated });
+                if (key_namespace === 6)
+                {
+                    if (!features_by_pos[matrix_pos]) features_by_pos[matrix_pos] = {};
+                    //if (keycode === 0x01) features_by_pos[matrix_pos].dks          = true; //needs different handling
+                    //if (keycode === 0x02) features_by_pos[matrix_pos].mod_tap      = true; //needs different handling
+                    //if (keycode === 0x03) features_by_pos[matrix_pos].toggle       = true; //needs different handling
+                    if (keycode === 0x04) features_by_pos[matrix_pos].rapid_snappy = true;
+                    if (keycode === 0x05) features_by_pos[matrix_pos].socd         = true;
+                }
+                else if (key_namespace === 0)
+                {
+                    active_keys.push({
+                        scancode: keycode,
+                        value:    value / 1023,
+                        extra:    { actuated, ...features_by_pos[matrix_pos] },
+                    });
+                }
             }
+
             handler(active_keys);
         };
     }

--- a/AnalogSense.js
+++ b/AnalogSense.js
@@ -415,7 +415,7 @@ class AsProviderWootingV2 extends AsProvider
                     //if (keycode === 0x01) features_by_pos[matrix_pos].dks          = true; //needs different handling
                     //if (keycode === 0x02) features_by_pos[matrix_pos].mod_tap      = true; //needs different handling
                     //if (keycode === 0x03) features_by_pos[matrix_pos].toggle       = true; //needs different handling
-                    if (keycode === 0x04) features_by_pos[matrix_pos].rapid_snappy = true;
+                    if (keycode === 0x04) features_by_pos[matrix_pos].rappy_snappy = true;
                     if (keycode === 0x05) features_by_pos[matrix_pos].socd         = true;
                 }
                 else if (key_namespace === 0)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Once loaded, the following global functions become available:
 - `analogsense.scancodeToString(scancode: number): string`
 
 A device instance has the following members:
-- `startListening(handler: function<void({scancode: int, value: float, actuated: 0 | 1 | null}[])>)`
+- `startListening(handler: function<void({scancode: int, value: float, extra: {actuated: bool, socd: bool, rappy_snappy: bool} | null}[])>)`
 - `stopListening()`
 - `getProductName(): string`
 - `forget()`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Once loaded, the following global functions become available:
 - `analogsense.scancodeToString(scancode: number): string`
 
 A device instance has the following members:
-- `startListening(handler: function<void({scancode: int, value: float}[])>)`
+- `startListening(handler: function<void({scancode: int, value: float, actuated: 0 | 1 | null}[])>)`
 - `stopListening()`
 - `getProductName(): string`
 - `forget()`

--- a/demo.html
+++ b/demo.html
@@ -48,8 +48,10 @@
                         const bar = document.createElement("div");
                         bar.className = "progress-bar";
                         bar.style.width = (key.value * 100) + "%";
-                        bar.style.backgroundColor = key.actuated ? "#7e28bf" : "";
+                        bar.style.backgroundColor = key.extra?.actuated ? "#7e28bf" : "";
                         bar.textContent = analogsense.scancodeToString(key.scancode);
+                        if (key.extra?.socd)         bar.textContent += " (socd enabled)";
+                        if (key.extra?.rapid_snappy) bar.textContent += " (rapid snappy enabled)";
                         div.appendChild(bar);
                     }
                     document.getElementById("active-keys").appendChild(div);

--- a/demo.html
+++ b/demo.html
@@ -48,6 +48,7 @@
                         const bar = document.createElement("div");
                         bar.className = "progress-bar";
                         bar.style.width = (key.value * 100) + "%";
+                        bar.style.backgroundColor = key.actuated ? "#7e28bf" : "";
                         bar.textContent = analogsense.scancodeToString(key.scancode);
                         div.appendChild(bar);
                     }

--- a/demo.html
+++ b/demo.html
@@ -51,7 +51,7 @@
                         bar.style.backgroundColor = key.extra?.actuated ? "#7e28bf" : "";
                         bar.textContent = analogsense.scancodeToString(key.scancode);
                         if (key.extra?.socd)         bar.textContent += " (socd enabled)";
-                        if (key.extra?.rapid_snappy) bar.textContent += " (rapid snappy enabled)";
+                        if (key.extra?.rappy_snappy) bar.textContent += " (rappy snappy enabled)";
                         div.appendChild(bar);
                     }
                     document.getElementById("active-keys").appendChild(div);


### PR DESCRIPTION
Now that we can get the actuated state from the interface it would be useful to also include it into active_keys

0 for not actuated, 1 for actuated and null/undefined for when its not supported (it might need a more clever type for easier handling)

however there is still a bit of work to be done that i didnt yet figure out... we need a way to differentiate from it being available via analog interface v2 or not since turning off rapid trigger via wootility will make `packed & 0x1` result in either 0 or 1 unrelated to the actuation (im assuming that its being used for something else with rt off)